### PR TITLE
Add raw log link that works without JS

### DIFF
--- a/src/bin/server/worker.rs
+++ b/src/bin/server/worker.rs
@@ -236,12 +236,13 @@ impl Worker {
         };
 
         let log_url = job.log_url().unwrap_or("unknown".into());
-        let log_url = format!(
+        let pretty_log_url = format!(
             "https://rust-lang.github.io/rust-log-analyzer/log-viewer/#{}",
-            log_url
+            &log_url
         );
+        let raw_log_url = log_url;
         self.github.post_comment(repo, pr, &format!(r#"
-{opening} [failed]({html_url}) ([raw log]({log_url})). Through arcane magic we have determined that the following fragments from the build log may contain information about the problem.
+{opening} [failed]({html_url}) ([pretty log]({log_url}), [raw log]({raw_log_url})). Through arcane magic we have determined that the following fragments from the build log may contain information about the problem.
 
 <details><summary><i>Click to expand the log.</i></summary>
 
@@ -252,7 +253,7 @@ impl Worker {
 </details><p></p>
 
 [I'm a bot](https://github.com/rust-ops/rust-log-analyzer)! I can only do what humans tell me to, so if this was not helpful or you have suggestions for improvements, please ping or otherwise contact **`@TimNN`**. ([Feature Requests](https://github.com/rust-ops/rust-log-analyzer/issues?q=is%3Aopen+is%3Aissue+label%3Afeature-request))
-        "#, opening = opening, html_url = job.html_url(), log_url = log_url, log = extracted))?;
+        "#, opening = opening, html_url = job.html_url(), log_url = pretty_log_url, raw_log_url = raw_log_url, log = extracted))?;
 
         Ok(())
     }


### PR DESCRIPTION
Some people are hitting CORS errors and we generally should provide an
option for folks not wanting to enable JS.