### PR TITLE
log-viewer: use <pre> to get monospace rendering instead of just a font.

### DIFF
--- a/log-viewer/index.html
+++ b/log-viewer/index.html
@@ -1,11 +1,14 @@
 <html>
-    <body style="font-family:Menlo, Consolas, Monaco, Liberation Mono, Lucida Console, monospace;">
+    <body>
         <noscript>
             This page needs JS to query the raw log contents.
         </noscript>
     </body>
     <script src="ansi_up.js"></script>
     <script>
+        let pre = document.createElement("pre");
+        document.body.appendChild(pre);
+
         async function getAndShow() {
             let url = window.location.hash.slice(1);
             if (url == "") {
@@ -18,8 +21,7 @@
             // FIXME: what is this escape code and why are we printing it?
             log = log.replace(/\u001b\(B/g, "");
             let ansi_up = new AnsiUp;
-            let html = ansi_up.ansi_to_html(log);
-            document.body.innerHTML = html.replace(/\n/g, "<br>");
+            pre.innerHTML = ansi_up.ansi_to_html(log);
         }
 
         getAndShow();


### PR DESCRIPTION
The [`<pre>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/pre) not only uses a monospace font, but also renders spaces without collapsing them, including `\n` (so we don't need to replace that with `<br>`).

With collapsed spaces (i.e. before this PR), this kind of error message:
```
2020-02-04T10:52:01.6262311Z 518 | /// + true  + [First]           +
2020-02-04T10:52:01.6263036Z     |                ^^^^^ cannot be resolved, ignoring
```
looked like this (IMO much less useful):
```
2020-02-04T10:52:01.6262311Z 518 | /// + true + [First] +
2020-02-04T10:52:01.6263036Z | ^^^^^ cannot be resolved, ignoring
```