### PR TITLE
Add support for configurable and multiple repositories

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -26,7 +26,7 @@ To initialize a new index file, perform the following steps:
 1. Download some successful build logs using the `rla-offline dl` command.
     * It is recommended that you run in `release` mode.
     * I'm still gathering data, but you should probably have well over 1000 log files (this does not mean over 1000 *builds*, since one builds consists of dozens of jobs)
-    * Example command: `rla-offline dl --ci travis -c 40 --branch auto --passed -o data/training`
+    * Example command: `rla-offline dl --ci actions --repo rust-lang/rust -c 40 --branch auto --passed -o data/training`
 2. Train on the downloaded logs using the `rla-offline learn command`.
     * Example command: `rla-offline learn -i demo.idx data/training`
 
@@ -42,7 +42,7 @@ To initialize a new index file, perform the following steps:
 *Note: This process will / should be integrated as regression tests.*
 
 1. Download, or otherwise curate, a set of log files you want to evaluate against.
-    * Example command: `rla-offline dl --ci travis -c 50 --failed -o data/failed`
+    * Example command: `rla-offline dl --ci actions --repo rust-lang/rust -c 50 --failed -o data/failed`
     * *Note: Eventually, a set of test log files will be provided in the repository.*
 2. Use the `rla-offline extract-dir` command to analyze all the log files and write the results to a separate directory.
     * You can (temporarily) check the result directory in to the repository to see diffs.

--- a/src/bin/offline/dl.rs
+++ b/src/bin/offline/dl.rs
@@ -29,6 +29,7 @@ pub fn cat(input: &Path, strip_control: bool, decode_utf8: bool) -> rla::Result<
 
 pub fn download(
     ci: &dyn CiPlatform,
+    repo: &str,
     output: &Path,
     count: u32,
     offset: u32,
@@ -45,7 +46,7 @@ pub fn download(
     let check_outcome = |outcome: &dyn rla::ci::Outcome| {
         (!only_passed || outcome.is_passed()) && (!only_failed || outcome.is_failed())
     };
-    let builds = ci.query_builds(count, offset, &|build| {
+    let builds = ci.query_builds(repo, count, offset, &|build| {
         (filter_branches.is_empty() || filter_branches.contains(build.branch_name()))
             && check_outcome(build.outcome())
     })?;

--- a/src/bin/rla-offline.rs
+++ b/src/bin/rla-offline.rs
@@ -112,6 +112,8 @@ enum Cli {
     Dl {
         #[structopt(long = "ci", help = "CI platform to download from.")]
         ci: util::CliCiPlatform,
+        #[structopt(long = "repo", help = "Repository to download from.")]
+        repo: String,
         #[structopt(short = "o", long = "output", help = "Log output directory.")]
         output: PathBuf,
         #[structopt(short = "c", long = "count", help = "Number of _builds_ to process.")]
@@ -158,6 +160,7 @@ fn main() {
         Cli::ExtractOne { index_file, log } => offline::extract::one(&index_file, &log),
         Cli::Dl {
             ci,
+            repo,
             output,
             count,
             skip,
@@ -166,6 +169,7 @@ fn main() {
             failed,
         } => offline::dl::download(
             ci.get()?.as_ref(),
+            &repo,
             &output,
             count,
             skip,

--- a/src/bin/rla-server.rs
+++ b/src/bin/rla-server.rs
@@ -64,6 +64,8 @@ struct Cli {
     webhook_verify: bool,
     #[structopt(long = "ci", help = "CI platform to interact with.")]
     ci: util::CliCiPlatform,
+    #[structopt(long = "repo", help = "Repository to interact with.")]
+    repo: String,
 }
 
 fn main() {
@@ -78,7 +80,7 @@ fn main() {
         let service = Arc::new(server::RlaService::new(args.webhook_verify, queue_send)?);
 
         let mut worker =
-            server::Worker::new(args.index_file, args.debug_post, queue_recv, args.ci.get()?)?;
+            server::Worker::new(args.index_file, args.debug_post, queue_recv, args.ci.get()?, args.repo)?;
 
         thread::spawn(move || {
             if let Err(e) = worker.main() {

--- a/src/bin/rla-server.rs
+++ b/src/bin/rla-server.rs
@@ -66,6 +66,13 @@ struct Cli {
     ci: util::CliCiPlatform,
     #[structopt(long = "repo", help = "Repository to interact with.")]
     repo: String,
+    #[structopt(
+        long = "secondary-repo",
+        help="Secondary repositories to listen for builds.",
+        required = false,
+        multiple = true
+    )]
+    secondary_repos: Vec<String>,
 }
 
 fn main() {
@@ -79,8 +86,14 @@ fn main() {
 
         let service = Arc::new(server::RlaService::new(args.webhook_verify, queue_send)?);
 
-        let mut worker =
-            server::Worker::new(args.index_file, args.debug_post, queue_recv, args.ci.get()?, args.repo)?;
+        let mut worker = server::Worker::new(
+            args.index_file,
+            args.debug_post,
+            queue_recv,
+            args.ci.get()?,
+            args.repo,
+            args.secondary_repos,
+        )?;
 
         thread::spawn(move || {
             if let Err(e) = worker.main() {

--- a/src/bin/rla-server.rs
+++ b/src/bin/rla-server.rs
@@ -73,6 +73,11 @@ struct Cli {
         multiple = true
     )]
     secondary_repos: Vec<String>,
+    #[structopt(
+        long = "query-builds-from-primary-repo",
+        help = "Always query builds from the primary repo instead of the repo receiving them."
+    )]
+    query_builds_from_primary_repo: bool,
 }
 
 fn main() {
@@ -93,6 +98,7 @@ fn main() {
             args.ci.get()?,
             args.repo,
             args.secondary_repos,
+            args.query_builds_from_primary_repo,
         )?;
 
         thread::spawn(move || {

--- a/src/bin/server/worker.rs
+++ b/src/bin/server/worker.rs
@@ -6,8 +6,6 @@ use std::collections::VecDeque;
 use std::path::PathBuf;
 use std::str;
 
-static REPO: &str = "rust-lang/rust";
-
 // We keep track of the last several unique job IDs. This is because
 // Azure sends us a notification for every individual builder's
 // state (around 70 notifications/job as of this time), but we want
@@ -34,6 +32,7 @@ pub struct Worker {
     queue: crossbeam::channel::Receiver<QueueItem>,
     seen: VecDeque<u64>,
     ci: Box<dyn CiPlatform + Send>,
+    repo: String,
 }
 
 impl Worker {
@@ -42,6 +41,7 @@ impl Worker {
         debug_post: Option<String>,
         queue: crossbeam::channel::Receiver<QueueItem>,
         ci: Box<dyn CiPlatform + Send>,
+        repo: String,
     ) -> rla::Result<Worker> {
         let debug_post = match debug_post {
             None => None,
@@ -65,6 +65,7 @@ impl Worker {
             seen: VecDeque::new(),
             queue,
             ci,
+            repo,
         })
     }
 
@@ -79,9 +80,9 @@ impl Worker {
     }
 
     fn process(&mut self, item: QueueItem) -> rla::Result<()> {
-        let build_id = match item {
+        let (repo, build_id) = match &item {
             QueueItem::GitHubStatus(ev) => match self.ci.build_id_from_github_status(&ev) {
-                Some(id) if ev.repository.full_name == REPO => id,
+                Some(id) if ev.repository.full_name == self.repo => (&ev.repository.full_name, id),
                 _ => {
                     info!(
                         "Ignoring invalid event (ctx: {:?}, url: {:?}).",
@@ -91,7 +92,7 @@ impl Worker {
                 }
             },
             QueueItem::GitHubCheckRun(ev) => match self.ci.build_id_from_github_check(&ev) {
-                Some(id) if ev.repository.full_name == REPO => id,
+                Some(id) if ev.repository.full_name == self.repo => (&ev.repository.full_name, id),
                 _ => {
                     info!(
                         "Ignoring invalid event (app id: {:?}, url: {:?}).",
@@ -113,7 +114,7 @@ impl Worker {
             self.seen.pop_back();
         }
 
-        let build = self.ci.query_build(build_id)?;
+        let build = self.ci.query_build(repo, build_id)?;
         if !build.outcome().is_finished() {
             info!("Ignoring in-progress build.");
             if let Some(idx) = self.seen.iter().position(|id| *id == build_id) {
@@ -169,7 +170,7 @@ impl Worker {
 
         let commit_info = self
             .github
-            .query_commit("rust-lang/rust", &build.commit_sha())?;
+            .query_commit(&self.repo, &build.commit_sha())?;
         let commit_message = commit_info.commit.message;
 
         let log_variables = rla::log_variables::LogVariables::extract(&lines);
@@ -196,7 +197,7 @@ impl Worker {
         };
 
         if !is_bors {
-            let pr_info = self.github.query_pr("rust-lang/rust", pr)?;
+            let pr_info = self.github.query_pr(&self.repo, pr)?;
 
             if !commit_message.starts_with("Merge ") {
                 bail!(
@@ -225,12 +226,12 @@ impl Worker {
         let (repo, pr) = match self.debug_post {
             Some((ref repo, pr_override)) => {
                 warn!(
-                    "Would post to 'rust-lang/rust#{}', debug override to '{}#{}'",
-                    pr, repo, pr_override
+                    "Would post to '{}#{}', debug override to '{}#{}'",
+                    self.repo, pr, repo, pr_override
                 );
-                (repo.as_ref(), pr_override)
+                (repo.as_str(), pr_override)
             }
-            None => ("rust-lang/rust", pr),
+            None => (self.repo.as_str(), pr),
         };
 
         let opening = match log_variables.job_name {

--- a/src/bin/util/mod.rs
+++ b/src/bin/util/mod.rs
@@ -5,8 +5,6 @@ use log;
 use std::env;
 use std::process;
 
-static REPO: &str = "rust-lang/rust";
-
 pub(crate) enum CliCiPlatform {
     Travis,
     Azure,
@@ -20,12 +18,12 @@ impl CliCiPlatform {
             CliCiPlatform::Azure => {
                 let token = std::env::var("AZURE_DEVOPS_TOKEN")
                     .with_context(|_| "failed to read AZURE_DEVOPS_TOKEN env var")?;
-                Box::new(rla::ci::AzurePipelines::new(REPO, &token))
+                Box::new(rla::ci::AzurePipelines::new(&token))
             }
             CliCiPlatform::Actions => {
                 let token = std::env::var("GITHUB_TOKEN")
                     .with_context(|_| "failed to read GITHUB_TOKEN env var")?;
-                Box::new(rla::ci::GitHubActions::new(REPO, &token))
+                Box::new(rla::ci::GitHubActions::new(&token))
             }
         })
     }

--- a/src/ci/mod.rs
+++ b/src/ci/mod.rs
@@ -43,11 +43,12 @@ pub trait CiPlatform {
 
     fn query_builds(
         &self,
+        repo: &str,
         count: u32,
         offset: u32,
         filter: &dyn Fn(&dyn Build) -> bool,
     ) -> Result<Vec<Box<dyn Build>>>;
-    fn query_build(&self, id: u64) -> Result<Box<dyn Build>>;
+    fn query_build(&self, repo: &str, id: u64) -> Result<Box<dyn Build>>;
 
     fn authenticate_request(&self, request: RequestBuilder) -> RequestBuilder {
         request

--- a/src/ci/travis.rs
+++ b/src/ci/travis.rs
@@ -226,6 +226,7 @@ impl CiPlatform for Client {
 
     fn query_builds(
         &self,
+        _repo: &str,
         mut count: u32,
         mut offset: u32,
         filter: &dyn Fn(&dyn Build) -> bool,
@@ -254,7 +255,7 @@ impl CiPlatform for Client {
         Ok(res)
     }
 
-    fn query_build(&self, id: u64) -> Result<Box<dyn Build>> {
+    fn query_build(&self, _repo: &str, id: u64) -> Result<Box<dyn Build>> {
         let mut resp = self.get(&format!("build/{}?include=build.jobs", id))?;
         if !resp.status().is_success() {
             bail!("Build query failed: {:?}", resp);


### PR DESCRIPTION
This PR adds support for customizing which repositories RLA interacts with, instead of hardcoding `rust-lang/rust` everywhere in the code. The change fixes missing reports for auto/try Azure builds (which broke after the switch to rust-lang-ci) and allows getting reports for auto/try GHA builds.

The first commit removes most hardcoded references to `rust-lang/rust`, replacing them with the `--repo` CLI flag. The flag is required by both the offline and the server CLI tools.

The second commit adds a `--secondary-repo` flag to the server CLI. The flag can  be specified multiple times, and adds repositories in which builds can run. If an incoming webhook was sent from a secondary repository the build will be fetched from it, but the comment will be posted in the primary repository. Practically speaking, this flag implements support for `rust-lang-ci/rust`.

The third commit adds a `--query-builds-from-primary-repo` to the server CLI. The flag is used in the Azure Pipelines configuration, and forces RLA to query builds received from a secondary repository in the primary one. This is needed as the Azure DevOps project for `rust-lang-ci/rust` is still called `rust-lang/rust`.

Notably, this PR does *not* change how Travis CI is handled. I don't have a test environment for it anymore and adding these changes to it is not trivial, as we use repository IDs instead of names to query the Travis CI API. I don't think it matters much as we don't use Travis CI anymore, and I'd almost be open to drop Travis CI support from RLA completely.

Before deploying this PR to production we will need to change the CLI invocation.

**New Azure Pipelines CLI invocation:**

```
rla-server --ci azure --repo rust-lang/rust --secondary-repo rust-lang-ci/rust --query-builds-from-primary-repo --index-file azure.idx
```

**New GitHub Actions CLI invocation:**

```
rla-server --ci actions --repo rust-lang/rust --secondary-repo rust-lang-ci/rust --index-file actions.idx
```

*The PR can be reviewed commit-by-commit.*
r? @Mark-Simulacrum 
Fixes #42 