### PR TITLE
Store index in S3, write index less times, and implement graceful shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,367 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "aws-config"
+version = "0.55.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd62464d1c4ad70f8b6cd693e7f30229f36bebdcdf3fce8c11803e1bdc0bc052"
+dependencies = [
+ "aws-credential-types",
+ "aws-http",
+ "aws-sdk-sso",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
+ "aws-smithy-json",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "http",
+ "hyper",
+ "ring",
+ "time",
+ "tokio",
+ "tower",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "0.55.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4232d3729eefc287adc0d5a8adc97b7d94eefffe6bbe94312cc86c7ab6b06ce"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-types",
+ "fastrand",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-endpoint"
+version = "0.55.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f04ab03b3f1cca91f7cccaa213056d732accb14e2e65debfacc1d28627d162"
+dependencies = [
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "aws-types",
+ "http",
+ "regex",
+ "tracing",
+]
+
+[[package]]
+name = "aws-http"
+version = "0.55.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ad8c53f7560baaf635b6aa811f3213d39b50555d100f83e43801652d4e318e"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "http",
+ "http-body",
+ "lazy_static",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-s3"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b64fc8b7d76d09e53f4a64ebe2cd44894adb902011a26878aebd0576234d41"
+dependencies = [
+ "aws-credential-types",
+ "aws-endpoint",
+ "aws-http",
+ "aws-sig-auth",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-checksums",
+ "aws-smithy-client",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
+ "aws-smithy-json",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "bytes",
+ "http",
+ "http-body",
+ "once_cell",
+ "percent-encoding",
+ "regex",
+ "tokio-stream",
+ "tower",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "143953d46f77a0b18480e7d8bb1a651080b9484e0bb94c27b8645eaeb3c3e231"
+dependencies = [
+ "aws-credential-types",
+ "aws-endpoint",
+ "aws-http",
+ "aws-sig-auth",
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
+ "aws-smithy-json",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "http",
+ "regex",
+ "tokio-stream",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7255c0d8053b89e8b5cdabb52e1dbf596e9968b1f45dce7a56b2cd57038fcfc9"
+dependencies = [
+ "aws-credential-types",
+ "aws-endpoint",
+ "aws-http",
+ "aws-sig-auth",
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
+ "aws-smithy-json",
+ "aws-smithy-query",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "bytes",
+ "http",
+ "regex",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sig-auth"
+version = "0.55.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d77d879ab210e958ba65a6d3842969a596738c024989cd3e490cf9f9b560ec"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-types",
+ "http",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "0.55.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ab4eebc8ec484fb9eab04b15a5d1e71f3dc13bee8fdd2d9ed78bcd6ecbd7192"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http",
+ "once_cell",
+ "percent-encoding",
+ "regex",
+ "sha2",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "0.55.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88573bcfbe1dcfd54d4912846df028b42d6255cbf9ce07be216b1bbfd11fc4b9"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "aws-smithy-checksums"
+version = "0.55.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71a63d4f1c04b3abb7603001e4513f19617427bf27ca185b2ac663a1e342d39e"
+dependencies = [
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "bytes",
+ "crc32c",
+ "crc32fast",
+ "hex",
+ "http",
+ "http-body",
+ "md-5",
+ "pin-project-lite",
+ "sha1",
+ "sha2",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-client"
+version = "0.55.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2f52352bae50d3337d5d6151b695d31a8c10ebea113eca5bead531f8301b067"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "lazy_static",
+ "pin-project-lite",
+ "rustls",
+ "tokio",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-eventstream"
+version = "0.55.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "168f08f8439c8b317b578a695e514c5cd7b869e73849a2d6b71ced4de6ce193d"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.55.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03bcc02d7ed9649d855c8ce4a735e9848d7b8f7568aad0504c158e3baa955df8"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http",
+ "http-body",
+ "hyper",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-tower"
+version = "0.55.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da88b3a860f65505996c29192d800f1aeb9480440f56d63aad33a3c12045017a"
+dependencies = [
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "bytes",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.55.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b0c1e87d75cac889dca2a7f5ba280da2cde8122448e7fec1d614194dfa00c70"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.55.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b50d15f446c19e088009ecb00e2fb2d13133d6fe1db702e9aa67ad135bf6a6"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "0.55.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0afc731fd1417d791f9145a1e0c30e23ae0beaab9b4814017708ead2fc20f1"
+dependencies = [
+ "base64-simd",
+ "itoa",
+ "num-integer",
+ "ryu",
+ "time",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.55.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b5398c1c25dfc6f8c282b1552a66aa807c9d6e15e1b3a84b94aa44e7859bec3"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "0.55.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9b082e329d9a304d39e193ad5c7ab363a0d6507aca6965e0673a746686fb0cc"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "http",
+ "rustc_version",
+ "tracing",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,6 +459,16 @@ name = "base64"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "bincode"
@@ -155,6 +526,16 @@ name = "bytes"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47d3a8076e283f3acd27400535992edb3ba4b5bb72f8891ad8fbe7932a7d4b9"
+dependencies = [
+ "bytes",
+ "either",
+]
 
 [[package]]
 name = "cc"
@@ -228,6 +609,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32c"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dfea2db42e9927a3845fb268a10a72faed6d416065f77873f05e411457c363e"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -323,6 +722,12 @@ name = "dotenv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+
+[[package]]
+name = "either"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "encoding_rs"
@@ -627,6 +1032,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
+dependencies = [
+ "http",
+ "hyper",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -749,6 +1169,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6365506850d44bff6e2fbcb5176cf63650e48bd45ef2fe2665ae1570e0f4b9ca"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -816,6 +1245,25 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -895,6 +1343,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
+name = "outref"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4030760ffd992bef45b0ae3f10ce1aba99e33464c90d14dd7c039884963ddc7a"
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -905,6 +1359,26 @@ name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+
+[[package]]
+name = "pin-project"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1039,6 +1513,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "rust-log-analyzer"
 version = "0.1.0"
 dependencies = [
@@ -1046,6 +1535,8 @@ dependencies = [
  "anyhow",
  "atomicwrites",
  "atty",
+ "aws-config",
+ "aws-sdk-s3",
  "bincode",
  "brotli",
  "clap",
@@ -1078,6 +1569,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.36.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1089,6 +1589,39 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
+dependencies = [
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
+dependencies = [
+ "base64",
 ]
 
 [[package]]
@@ -1122,6 +1655,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1143,6 +1686,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
@@ -1196,6 +1745,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1228,6 +1788,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "strsim"
@@ -1305,6 +1871,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
+dependencies = [
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+
+[[package]]
+name = "time-macros"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
+dependencies = [
+ "time-core",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1347,6 +1939,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+dependencies = [
+ "rustls",
+ "tokio",
+ "webpki",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fb52b74f05dbf495a8fba459fdc331812b96aa086d9eb78101fa0d4569c3313"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1361,6 +1975,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1373,6 +2009,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -1462,6 +2099,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
 name = "url"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1471,6 +2114,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
 
 [[package]]
 name = "valuable"
@@ -1489,6 +2138,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "walkdir"
@@ -1590,6 +2245,16 @@ checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -1712,3 +2377,15 @@ checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "xmlparser"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d25c75bf9ea12c4040a97f829154768bbbce366287e2dc044af160cd79a13fd"
+
+[[package]]
+name = "zeroize"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1765,6 +1765,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1924,8 +1933,21 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,5 @@ tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 atty = "0.2.14"
 clap = { version = "4.1.8", features = ["derive"] }
 tokio = { version = "1.26.0", features = ["rt-multi-thread", "rt"] }
+aws-sdk-s3 = "0.26.0"
+aws-config = "0.55.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,6 @@ tracing = "0.1.16"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 atty = "0.2.14"
 clap = { version = "4.1.8", features = ["derive"] }
-tokio = { version = "1.26.0", features = ["rt-multi-thread", "rt"] }
+tokio = { version = "1.26.0", features = ["rt-multi-thread", "rt", "signal", "macros"] }
 aws-sdk-s3 = "0.26.0"
 aws-config = "0.55.1"

--- a/Readme.md
+++ b/Readme.md
@@ -47,3 +47,10 @@ To initialize a new index file, perform the following steps:
     * You can (temporarily) check the result directory in to the repository to see diffs.
     * Example command: `rla-offline extract-dir --ci actions -i demo.idx -s data/failed -d data/err`
     * *Note: Eventually, the expected results for the test log files will be provided in the repository and used as regression tests.*
+
+### Index file storage
+
+The index file can be stored either in the local filesystem (by providing the
+absolute or relative path to the file) or in S3 (by providing a
+`s3://{bucket}/{key}` URL). The S3 region of the bucket is detected
+automatically at startup.

--- a/src/bin/offline/extract.rs
+++ b/src/bin/offline/extract.rs
@@ -1,6 +1,7 @@
 use crate::offline;
 use crate::rla;
 
+use rla::index::IndexStorage;
 use std::fs;
 use std::io::{self, Write};
 use std::path::Path;
@@ -31,7 +32,7 @@ fn load_lines<'a>(ci: &dyn rla::ci::CiPlatform, log: &'a [u8]) -> Vec<Line<'a>> 
 
 pub fn dir(
     ci: &dyn rla::ci::CiPlatform,
-    index_file: &Path,
+    index_file: &IndexStorage,
     src_dir: &Path,
     dst_dir: &Path,
 ) -> rla::Result<()> {
@@ -91,7 +92,11 @@ pub fn dir(
     Ok(())
 }
 
-pub fn one(ci: &dyn rla::ci::CiPlatform, index_file: &Path, log_file: &Path) -> rla::Result<()> {
+pub fn one(
+    ci: &dyn rla::ci::CiPlatform,
+    index_file: &IndexStorage,
+    log_file: &Path,
+) -> rla::Result<()> {
     let config = rla::extract::Config::default();
     let index = rla::Index::load(index_file)?;
 

--- a/src/bin/offline/learn.rs
+++ b/src/bin/offline/learn.rs
@@ -1,14 +1,15 @@
 use crate::offline;
 use crate::rla;
 
-use std::path::{Path, PathBuf};
+use rla::index::IndexStorage;
+use std::path::PathBuf;
 use std::time::Duration;
 use std::time::Instant;
 use walkdir::{self, WalkDir};
 
 pub fn learn(
     ci: &dyn rla::ci::CiPlatform,
-    index_file: &Path,
+    index_file: &IndexStorage,
     inputs: &[PathBuf],
     multiplier: u32,
 ) -> rla::Result<()> {

--- a/src/bin/rla-offline.rs
+++ b/src/bin/rla-offline.rs
@@ -12,6 +12,7 @@ extern crate rust_log_analyzer as rla;
 extern crate walkdir;
 
 use clap::Parser;
+use rla::index::IndexStorage;
 use std::path::PathBuf;
 
 mod offline;
@@ -53,7 +54,7 @@ enum Cli {
             long = "index-file",
             help = "The index file to read / write. An existing index file is updated."
         )]
-        index_file: PathBuf,
+        index_file: IndexStorage,
         #[arg(
             short = 'm',
             long = "multiplier",
@@ -79,7 +80,7 @@ enum Cli {
             long = "index-file",
             help = "The index file to read / write."
         )]
-        index_file: PathBuf,
+        index_file: IndexStorage,
         #[arg(
             short = 's',
             long = "source",
@@ -106,7 +107,7 @@ enum Cli {
             long = "index-file",
             help = "The index file to read / write."
         )]
-        index_file: PathBuf,
+        index_file: IndexStorage,
         #[arg(help = "The log file to analyze.")]
         log: PathBuf,
     },

--- a/src/bin/rla-server.rs
+++ b/src/bin/rla-server.rs
@@ -15,6 +15,7 @@ extern crate rust_log_analyzer as rla;
 extern crate serde_json;
 
 use clap::Parser;
+use rla::index::IndexStorage;
 use std::process;
 use std::sync::Arc;
 use std::thread;
@@ -47,7 +48,7 @@ struct Cli {
         long = "index-file",
         help = "The index file to read / write. An existing index file is updated."
     )]
-    index_file: std::path::PathBuf,
+    index_file: IndexStorage,
     #[arg(
         long = "debug-post",
         help = "Post all comments to the given issue instead of the actual PR. Format: \"user/repo#id\""

--- a/src/bin/rla-server.rs
+++ b/src/bin/rla-server.rs
@@ -14,7 +14,9 @@ extern crate regex;
 extern crate rust_log_analyzer as rla;
 extern crate serde_json;
 
+use crate::server::QueueItem;
 use clap::Parser;
+use crossbeam::channel::Sender;
 use rla::index::IndexStorage;
 use std::process;
 use std::sync::Arc;
@@ -91,7 +93,10 @@ fn main() {
 
         let (queue_send, queue_recv) = crossbeam::channel::unbounded();
 
-        let service = Arc::new(server::RlaService::new(args.webhook_verify, queue_send)?);
+        let service = Arc::new(server::RlaService::new(
+            args.webhook_verify,
+            queue_send.clone(),
+        )?);
 
         let mut worker = server::Worker::new(
             args.index_file,
@@ -103,7 +108,7 @@ fn main() {
             args.query_builds_from_primary_repo,
         )?;
 
-        thread::spawn(move || {
+        let worker_thread = thread::spawn(move || {
             if let Err(e) = worker.main() {
                 error!("Worker failed, exiting: {}", e);
                 process::exit(1);
@@ -126,9 +131,34 @@ fn main() {
                         }))
                     }
                 }))
+                .with_graceful_shutdown(graceful_shutdown(queue_send))
                 .await
         })?;
 
+        worker_thread.join().expect("worker thread failed");
+
         Ok(())
     });
+}
+
+async fn graceful_shutdown(sender: Sender<QueueItem>) {
+    let ctrl_c = tokio::signal::ctrl_c();
+
+    // ECS uses SIGTERM to signal graceful shutdown must begin.
+    #[cfg(unix)]
+    let mut sigterm =
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()).unwrap();
+    #[cfg(unix)]
+    let sigterm = sigterm.recv();
+
+    #[cfg(not(unix))]
+    let sigterm = std::future::pending(); // Never resolves
+
+    tokio::select! {
+        _ = ctrl_c => {}
+        _ = sigterm => {}
+    };
+
+    info!("graceful shutdown signal received");
+    let _ = sender.send(QueueItem::GracefulShutdown);
 }

--- a/src/bin/server/mod.rs
+++ b/src/bin/server/mod.rs
@@ -6,13 +6,27 @@ pub use self::worker::Worker;
 mod service;
 mod worker;
 
-pub struct QueueItem {
-    pub kind: QueueItemKind,
-    pub delivery_id: String,
+pub enum QueueItem {
+    GitHubStatus {
+        payload: rla::github::CommitStatusEvent,
+        delivery_id: String,
+    },
+    GitHubCheckRun {
+        payload: rla::github::CheckRunEvent,
+        delivery_id: String,
+    },
+    GitHubPullRequest {
+        payload: rla::github::PullRequestEvent,
+        delivery_id: String,
+    },
 }
 
-pub enum QueueItemKind {
-    GitHubStatus(rla::github::CommitStatusEvent),
-    GitHubCheckRun(rla::github::CheckRunEvent),
-    GitHubPullRequest(rla::github::PullRequestEvent),
+impl QueueItem {
+    fn delivery_id(&self) -> Option<&str> {
+        match self {
+            QueueItem::GitHubStatus { delivery_id, .. } => Some(&delivery_id),
+            QueueItem::GitHubCheckRun { delivery_id, .. } => Some(&delivery_id),
+            QueueItem::GitHubPullRequest { delivery_id, .. } => Some(&delivery_id),
+        }
+    }
 }

--- a/src/bin/server/mod.rs
+++ b/src/bin/server/mod.rs
@@ -19,6 +19,7 @@ pub enum QueueItem {
         payload: rla::github::PullRequestEvent,
         delivery_id: String,
     },
+    GracefulShutdown,
 }
 
 impl QueueItem {
@@ -27,6 +28,7 @@ impl QueueItem {
             QueueItem::GitHubStatus { delivery_id, .. } => Some(&delivery_id),
             QueueItem::GitHubCheckRun { delivery_id, .. } => Some(&delivery_id),
             QueueItem::GitHubPullRequest { delivery_id, .. } => Some(&delivery_id),
+            QueueItem::GracefulShutdown => None,
         }
     }
 }

--- a/src/bin/server/worker.rs
+++ b/src/bin/server/worker.rs
@@ -349,8 +349,8 @@ impl Worker {
         // time elapsed since the last save.
         match self.last_index_backup {
             Some(last) if last.elapsed() >= MINIMUM_DELAY_BETWEEN_INDEX_BACKUPS => {
-                self.index.save(&self.index_file)?;
                 self.last_index_backup = Some(Instant::now());
+                self.index.save(&self.index_file)?;
             }
             Some(_) => {}
             None => self.last_index_backup = Some(Instant::now()),

--- a/src/bin/server/worker.rs
+++ b/src/bin/server/worker.rs
@@ -3,14 +3,14 @@ use super::{QueueItem, QueueItemKind};
 use crate::rla;
 use crate::rla::ci::{self, BuildCommit, CiPlatform};
 use anyhow::bail;
+use rla::index::IndexStorage;
 use std::collections::{HashSet, VecDeque};
 use std::hash::Hash;
-use std::path::PathBuf;
 use std::str;
 
 pub struct Worker {
     debug_post: Option<(String, u32)>,
-    index_file: PathBuf,
+    index_file: IndexStorage,
     index: rla::Index,
     extract_config: rla::extract::Config,
     github: rla::github::Client,
@@ -26,7 +26,7 @@ pub struct Worker {
 
 impl Worker {
     pub fn new(
-        index_file: PathBuf,
+        index_file: IndexStorage,
         debug_post: Option<String>,
         queue: crossbeam::channel::Receiver<QueueItem>,
         ci: Box<dyn CiPlatform + Send>,

--- a/src/index/storage.rs
+++ b/src/index/storage.rs
@@ -1,30 +1,48 @@
 use crate::{Index, Result};
+use anyhow::anyhow;
 use atomicwrites::{AtomicFile, OverwriteBehavior};
+use aws_sdk_s3::config::Region;
+use aws_sdk_s3::error::SdkError;
+use aws_sdk_s3::operation::get_object::GetObjectError;
+use aws_sdk_s3::Client as S3Client;
 use std::fs::File;
+use std::io::Cursor;
 use std::path::PathBuf;
 use std::str::FromStr;
+use std::sync::Arc;
+use tokio::runtime::Runtime;
 
 #[derive(Debug, Clone)]
 pub enum IndexStorage {
     FileSystem(FileSystemStorage),
+    S3(Arc<S3Storage>),
 }
 
 impl IndexStorage {
     pub fn new(path: &str) -> Result<Self> {
-        Ok(IndexStorage::FileSystem(FileSystemStorage {
-            path: path.into(),
-        }))
+        if let Some(s3_url) = path.strip_prefix("s3://") {
+            let (bucket, key) = s3_url
+                .split_once('/')
+                .ok_or_else(|| anyhow!("invalid s3 url: {path}"))?;
+            Ok(IndexStorage::S3(Arc::new(S3Storage::new(bucket, key)?)))
+        } else {
+            Ok(IndexStorage::FileSystem(FileSystemStorage {
+                path: path.into(),
+            }))
+        }
     }
 
     pub(super) fn read(&self) -> Result<Option<Index>> {
         match self {
             IndexStorage::FileSystem(fs) => fs.read(),
+            IndexStorage::S3(s3) => s3.read(),
         }
     }
 
     pub(super) fn write(&self, index: &Index) -> Result<()> {
         match self {
             IndexStorage::FileSystem(fs) => fs.write(index),
+            IndexStorage::S3(s3) => s3.write(index),
         }
     }
 }
@@ -41,6 +59,7 @@ impl std::fmt::Display for IndexStorage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             IndexStorage::FileSystem(fs) => write!(f, "{}", fs.path.display()),
+            IndexStorage::S3(s3) => write!(f, "s3://{}/{}", s3.bucket, s3.key),
         }
     }
 }
@@ -64,5 +83,101 @@ impl FileSystemStorage {
         let file = AtomicFile::new(&self.path, OverwriteBehavior::AllowOverwrite);
         file.write(|inner| index.serialize(inner))?;
         Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub struct S3Storage {
+    runtime: Runtime,
+    client: S3Client,
+    bucket: String,
+    key: String,
+}
+
+impl S3Storage {
+    fn new(bucket: &str, key: &str) -> Result<Self> {
+        let runtime = Runtime::new()?;
+
+        let config = runtime.block_on(async {
+            let global_config = aws_config::load_from_env().await;
+            let global_s3 = S3Client::new(&global_config);
+
+            let location = global_s3
+                .get_bucket_location()
+                .bucket(bucket)
+                .send()
+                .await?;
+            let region = location
+                .location_constraint()
+                .map(|c| c.as_str())
+                .unwrap_or("us-east-1")
+                .to_string();
+
+            info!("using S3 bucket {bucket} in region {region}");
+
+            let regional_config = aws_config::from_env()
+                .region(Region::new(region))
+                .load()
+                .await;
+
+            Ok::<_, anyhow::Error>(regional_config)
+        })?;
+        let client = S3Client::new(&config);
+
+        Ok(S3Storage {
+            runtime,
+            client,
+            bucket: bucket.into(),
+            key: key.into(),
+        })
+    }
+
+    fn read(&self) -> Result<Option<Index>> {
+        self.runtime.block_on(async {
+            let result = self
+                .client
+                .get_object()
+                .bucket(&self.bucket)
+                .key(&self.key)
+                .send()
+                .await;
+
+            match result {
+                Ok(response) => {
+                    // FIXME: this buffers the downloaded data into memory before deserializing it,
+                    // as I'm not aware of a way to convert from AsyncRead to Read.
+                    let mut buf = Vec::new();
+                    tokio::io::copy(&mut response.body.into_async_read(), &mut buf).await?;
+                    Ok(Some(Index::deserialize(&mut Cursor::new(buf))?))
+                }
+                Err(err) => {
+                    if let SdkError::ServiceError(service_err) = &err {
+                        if let GetObjectError::NoSuchKey(_) = service_err.err() {
+                            return Ok(None);
+                        }
+                    }
+                    Err(err.into())
+                }
+            }
+        })
+    }
+
+    fn write(&self, index: &Index) -> Result<()> {
+        self.runtime.block_on(async {
+            // FIXME: this buffers the serialized data into memory before sending it, as I'm not
+            // aware of a way to convert from Write to AsyncWrite.
+            let mut buf = Vec::new();
+            index.serialize(&mut Cursor::new(&mut buf))?;
+
+            self.client
+                .put_object()
+                .bucket(&self.bucket)
+                .key(&self.key)
+                .body(buf.into())
+                .send()
+                .await?;
+
+            Ok(())
+        })
     }
 }

--- a/src/index/storage.rs
+++ b/src/index/storage.rs
@@ -1,0 +1,68 @@
+use crate::{Index, Result};
+use atomicwrites::{AtomicFile, OverwriteBehavior};
+use std::fs::File;
+use std::path::PathBuf;
+use std::str::FromStr;
+
+#[derive(Debug, Clone)]
+pub enum IndexStorage {
+    FileSystem(FileSystemStorage),
+}
+
+impl IndexStorage {
+    pub fn new(path: &str) -> Result<Self> {
+        Ok(IndexStorage::FileSystem(FileSystemStorage {
+            path: path.into(),
+        }))
+    }
+
+    pub(super) fn read(&self) -> Result<Option<Index>> {
+        match self {
+            IndexStorage::FileSystem(fs) => fs.read(),
+        }
+    }
+
+    pub(super) fn write(&self, index: &Index) -> Result<()> {
+        match self {
+            IndexStorage::FileSystem(fs) => fs.write(index),
+        }
+    }
+}
+
+impl FromStr for IndexStorage {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        IndexStorage::new(s)
+    }
+}
+
+impl std::fmt::Display for IndexStorage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            IndexStorage::FileSystem(fs) => write!(f, "{}", fs.path.display()),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FileSystemStorage {
+    path: PathBuf,
+}
+
+impl FileSystemStorage {
+    fn read(&self) -> Result<Option<Index>> {
+        let mut file = match File::open(&self.path) {
+            Ok(file) => file,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(err) => return Err(err.into()),
+        };
+        Ok(Some(Index::deserialize(&mut file)?))
+    }
+
+    fn write(&self, index: &Index) -> Result<()> {
+        let file = AtomicFile::new(&self.path, OverwriteBehavior::AllowOverwrite);
+        file.write(|inner| index.serialize(inner))?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR changes how we read and write the index, to improve performance and remove reliance on EFS in production. The changes included in this PR are:

* Read and write from S3 instead of disk when the index path is `s3://{bucket}/{path}`.
* Implement graceful shutdown and persist the index on shutdown.
* Since we now persist the index at shutdown, persist the index during learning only if the index was not already persisted in the past hour. This should not have an impact during day-to-day use, as graceful shutdown will take care of persisting the latest changes of shutdown, but will serve as a backup if graceful shutdown doesn't work for some reason.

This PR is best reviewed commit-by-commit.