### PR TITLE
Learn from PR builds too

### DIFF
--- a/src/bin/server/worker.rs
+++ b/src/bin/server/worker.rs
@@ -171,11 +171,11 @@ impl Worker {
         if !outcome.is_passed() {
             self.report_failed(build_id, build.as_ref())?;
         }
-        if build.pr_number().is_none() && build.branch_name() == "auto" {
+        if build.pr_number().is_some() || build.branch_name() == "auto" {
             info!("learning from the log");
             self.learn(build.as_ref())?;
         } else {
-            info!("did not learn as it's not an auto build");
+            info!("did not learn as it's not an auto build or a PR build");
         }
 
         Ok(ProcessOutcome::Continue)


### PR DESCRIPTION
After talking with some folks at RustWeek, I discovered that the RLA output for PR builds is suboptimal, as we are not learning from PR build logs. Originally we were only learning from auto builds to avoid the risk of a PR build poisoning RLA, but that risk is less than the downside of having bad error logs. This PR thus enables learning from PR build logs.