### PR TITLE
Add enhanced plain logs link to triagebot

### DIFF
--- a/src/bin/server/worker.rs
+++ b/src/bin/server/worker.rs
@@ -299,10 +299,14 @@ impl Worker {
             Some(url) => format!("\nFor more information how to resolve CI failures of this job, visit this [link]({url})."),
             None => "".to_string(),
         };
+        let plain_enhanced = match job.log_enhanced_url() {
+            Some(enhanced_url) => format!(" [(plain enhanced)]({enhanced_url})"),
+            None => "".to_string(),
+        };
 
         let log_url = job.log_url().unwrap_or_else(|| "unknown".into());
         self.github.post_comment(repo, pr, &format!(r#"
-{opening} failed! Check out the build log: [(web)]({html_url}) [(plain)]({log_url})
+{opening} failed! Check out the build log: [(web)]({html_url}){plain_enhanced} [(plain)]({log_url})
 
 <details><summary><i>Click to see the possible cause of the failure (guessed by this bot)</i></summary>
 
@@ -311,7 +315,7 @@ impl Worker {
 ```
 
 </details>
-{trailer}"#, opening = opening, html_url = job.html_url(), log_url = log_url, log = extracted, trailer = trailer))?;
+{trailer}"#, opening = opening, html_url = job.html_url(), plain_enhanced = plain_enhanced, log_url = log_url, log = extracted, trailer = trailer))?;
 
         info!("marked build {} as recently notified", build_id);
         self.recently_notified.store(build_id);

--- a/src/ci/actions.rs
+++ b/src/ci/actions.rs
@@ -113,6 +113,13 @@ impl Job for GHAJob {
         ))
     }
 
+    fn log_enhanced_url(&self) -> Option<String> {
+        Some(format!(
+            "https://triage.rust-lang.org/gha-logs/{}/{}",
+            self.repo_name, self.inner.id
+        ))
+    }
+
     fn log_file_name(&self) -> String {
         format!("actions-{}-{}", self.inner.id, self.inner.name)
     }

--- a/src/ci/mod.rs
+++ b/src/ci/mod.rs
@@ -41,6 +41,10 @@ pub trait Job: std::fmt::Display {
     fn log_api_url(&self) -> Option<String> {
         self.log_url()
     }
+
+    fn log_enhanced_url(&self) -> Option<String> {
+        None
+    }
 }
 
 pub trait CiPlatform {


### PR DESCRIPTION
This is a follow-up to https://github.com/rust-lang/triagebot/pull/2076 to automatically link to triagebot new `/gha-logs/:owner/:repo/:log-id` endpoint which displays ANSI-processed GHA logs.

I choose to add the link as an extra link: `(plain enhanced)`, so that users can still go to the web version or plain raw logs if they which.

r? @Kobzol 