### PR TITLE
Make failed job doc URL more visible

### DIFF
--- a/src/bin/server/worker.rs
+++ b/src/bin/server/worker.rs
@@ -296,7 +296,11 @@ impl Worker {
             None => "A job".to_owned(),
         };
         let trailer = match log_variables.doc_url {
-            Some(url) => format!("\nFor more information how to resolve CI failures of this job, visit this [link]({url})."),
+            Some(url) => format!(
+                r#"
+> [!IMPORTANT]
+> For more information how to resolve CI failures of this job, visit this [link]({url})."#
+            ),
             None => "".to_string(),
         };
         let plain_enhanced = match job.log_enhanced_url() {


### PR DESCRIPTION
Based on some recent confusion about the new trait solver stabilization job, I think that the URL is not visible enough. This PR should make that better.

Example: https://github.com/rust-lang/rust/pull/158035#issuecomment-4751228157
